### PR TITLE
Fix Upload Metric Bug

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -3,11 +3,11 @@ run:
 linters:
   enable:
     - bodyclose
+    - copyloopvar
     - depguard
     - dogsled
     - dupl
     - durationcheck
-    - exportloopref
     - exhaustive
     - gochecknoinits
     - goconst

--- a/pkg/rtorrentexporter/downloadscollector.go
+++ b/pkg/rtorrentexporter/downloadscollector.go
@@ -324,8 +324,13 @@ func (c *DownloadsCollector) parseDownloadDetailsMetrics(a []any, cmds []string,
 		return err
 	}
 
-	for idx, v := range a[2:] {
-		switch cmds[idx] {
+	// collect metrics starting without hash or name (starting at index 2 and beyond), cannot put this directly in range because it creates
+	// a new slice starting with index 0 which makes it not able to match the correct command
+	abbrA := a[2:]
+	abbrCommands := cmds[2:]
+
+	for idx, v := range abbrA {
+		switch abbrCommands[idx] {
 		case "d.down.rate=":
 			down, ok := v.(int64)
 			if !ok {

--- a/pkg/rtorrentexporter/downloadscollector_test.go
+++ b/pkg/rtorrentexporter/downloadscollector_test.go
@@ -150,7 +150,7 @@ func TestDownloadsCollector_parseDownloadDetailsMetrics(t *testing.T) {
 	collector := NewDownloadsCollector(nil, CollectorOpts{DownloadDetails: true})
 	ch := make(chan prometheus.Metric)
 	a := []any{"hash1", "name1", int64(100), int64(200), int64(300), int64(400)}
-	cmds := []string{"d.down.rate=", "d.down.total=", "d.up.rate=", "d.up.total="}
+	cmds := []string{"d.hash=", "d.base_filename=", "d.down.rate=", "d.down.total=", "d.up.rate=", "d.up.total="}
 
 	go func() {
 		defer close(ch)


### PR DESCRIPTION
In release v1.1.0 upload total bytes and upload rate were not being tracked correctly because of Golang array semantics.

This fixes that issue.