### PR TITLE
feat: add torrent errors and tracker messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ Specific additions made by this fork:
 * Support self-signed (non-official) certificates
 * Allow setting timeouts on all HTTP / XMLRPC calls
 * Allow disabling high-cardinality metrics (`-rtorrent.downloads.collect.details`)
+* Reports torrents with errors via `rtorrent_downloads_error` gauge
+* Reports tracker messages via `rtorrent_downloads_messages` (can be disabled by setting `-rtorrent.downloads.collect.messages` to `false`
 * Improve performance for greater numbers of torrents (especially helpful if you have >100 torrents)
 
 Command `rtorrent-exporter` provides a Prometheus exporter for rTorrent.
@@ -28,18 +30,20 @@ Usage
 Available flags for `rtorrent-exporter` include:
 
 ```sh
-% ./rtorrent-exporter --help
-Usage of ./rtorrent-exporter:
+% ./rtorrent_exporter --help
+Usage of ./rtorrent_exporter:
   -rtorrent.addr string
         address of rTorrent XML-RPC server
   -rtorrent.downloads.collect.details
-        [optional] collect rate and total bytes for each torrent (greatly increases metric cardinality) (defaults: true) (default true)
+        [optional] collect rate and total bytes for each torrent (greatly increases metric cardinality) (default true)
+  -rtorrent.downloads.collect.messages
+        [optional] collect messages for each torrent (greatly increases metric cardinality) (default true)
   -rtorrent.insecure
         [optional] allow using XML-RPC with a non-CA signed certificat (defaults: false)
   -rtorrent.password string
         [optional] password used for HTTP Basic authentication with rTorrent XML-RPC server
   -rtorrent.timeout duration
-        [optional] duration of how long to wait before timing out rtorrent request (defaults: 10s) (default 10s)
+        [optional] duration of how long to wait before timing out rtorrent request (default 10s)
   -rtorrent.username string
         [optional] username used for HTTP Basic authentication with rTorrent XML-RPC server
   -telemetry.addr string
@@ -47,7 +51,7 @@ Usage of ./rtorrent-exporter:
   -telemetry.path string
         URL path for surfacing collected metrics (default "/metrics")
   -telemetry.timeout duration
-        [optional] duration of how long to wait to receive http headers on telemetry addr (defaults: 10s) (default 10s)
+        [optional] duration of how long to wait to receive http headers on telemetry addr (default 10s)
 ```
 
 An example of using `rtorrent-exporter`:

--- a/cmd/rtorrent_exporter/main.go
+++ b/cmd/rtorrent_exporter/main.go
@@ -21,7 +21,7 @@ var (
 	telemetryAddr    = flag.String("telemetry.addr", ":9135", "host:port for rTorrent exporter")
 	metricsPath      = flag.String("telemetry.path", "/metrics", "URL path for surfacing collected metrics")
 	telemetryTimeout = flag.Duration("telemetry.timeout", 10*time.Second,
-		"[optional] duration of how long to wait to receive http headers on telemetry addr (defaults: 10s)")
+		"[optional] duration of how long to wait to receive http headers on telemetry addr")
 
 	rtorrentAddr     = flag.String("rtorrent.addr", "", "address of rTorrent XML-RPC server")
 	rtorrentUsername = flag.String("rtorrent.username", "",
@@ -31,9 +31,11 @@ var (
 	rtorrentInsecure = flag.Bool("rtorrent.insecure", false,
 		"[optional] allow using XML-RPC with a non-CA signed certificat (defaults: false)")
 	rtorrentTimeout = flag.Duration("rtorrent.timeout", 10*time.Second,
-		"[optional] duration of how long to wait before timing out rtorrent request (defaults: 10s)")
+		"[optional] duration of how long to wait before timing out rtorrent request")
 	rtorrentDownloadsCollectDetails = flag.Bool("rtorrent.downloads.collect.details", true,
-		"[optional] collect rate and total bytes for each torrent (greatly increases metric cardinality) (defaults: true)")
+		"[optional] collect rate and total bytes for each torrent (greatly increases metric cardinality)")
+	rtorrentDownloadsCollectMessages = flag.Bool("rtorrent.downloads.collect.messages", true,
+		"[optional] collect messages for each torrent (greatly increases metric cardinality)")
 )
 
 func main() {
@@ -75,7 +77,8 @@ func main() {
 	}
 
 	colOpts := rtorrentexporter.CollectorOpts{
-		DownloadDetails: *rtorrentDownloadsCollectDetails,
+		DownloadDetails:  *rtorrentDownloadsCollectDetails,
+		DownloadMessages: *rtorrentDownloadsCollectMessages,
 	}
 
 	prometheus.MustRegister(rtorrentexporter.New(c, colOpts))
@@ -86,9 +89,11 @@ func main() {
 	})
 
 	log.Printf("starting rTorrent exporter on %q for server %q (telemetry timeout: %v) "+
-		"(authentication: %v) (insecure: %v) (timeout: %v) (collect download details: %v)",
+		"(authentication: %v) (insecure: %v) (timeout: %v) (collect download details: %v) (collect messages: %v)",
 		*telemetryAddr, *rtorrentAddr, *telemetryTimeout,
-		authEnabled, *rtorrentInsecure, *rtorrentTimeout, *rtorrentDownloadsCollectDetails)
+		authEnabled, *rtorrentInsecure, *rtorrentTimeout, *rtorrentDownloadsCollectDetails,
+		*rtorrentDownloadsCollectMessages,
+	)
 
 	server := &http.Server{
 		Addr:              *telemetryAddr,

--- a/pkg/rtorrentexporter/downloadscollector.go
+++ b/pkg/rtorrentexporter/downloadscollector.go
@@ -43,11 +43,14 @@ type DownloadsCollector struct {
 	DownloadsSeeding    *prometheus.Desc
 	DownloadsLeeching   *prometheus.Desc
 	DownloadsActive     *prometheus.Desc
+	DownloadsError      *prometheus.Desc
 
 	DownloadRateBytes  *prometheus.Desc
 	DownloadTotalBytes *prometheus.Desc
 	UploadRateBytes    *prometheus.Desc
 	UploadTotalBytes   *prometheus.Desc
+
+	DownloadMessages *prometheus.Desc
 
 	ds DownloadsSource
 
@@ -55,12 +58,14 @@ type DownloadsCollector struct {
 }
 
 type CollectorOpts struct {
-	DownloadDetails bool
-	CollectURLs     bool
+	DownloadDetails  bool
+	DownloadMessages bool
+	CollectURLs      bool
 }
 
 var (
-	defaultActiveCommands = []string{"d.hash=", "d.base_filename=", "d.down.rate=", "d.down.total=", "d.up.rate=", "d.up.total="}
+	defaultActiveCommands = []string{"d.hash=", "d.base_filename=", "d.down.rate=", "d.down.total=", "d.up.rate=", "d.up.total=",
+		"d.message="}
 )
 
 // Verify that DownloadsCollector implements the prometheus.Collector interface.
@@ -173,6 +178,23 @@ func NewDownloadsCollector(ds DownloadsSource, collectorOpts CollectorOpts) *Dow
 			prometheus.BuildFQName(namespace, subsystem, "upload_total_bytes"),
 			"Total Bytes uploaded.",
 			labels,
+			nil,
+		)
+
+		downCollector.DownloadsError = prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, subsystem, "error"),
+			"Number of downloads with tracker errors.",
+			nil,
+			nil,
+		)
+	}
+
+	if downCollector.collectOpts.DownloadMessages {
+		msgLabels := append(labels, "message")
+		downCollector.DownloadMessages = prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, subsystem, "messages"),
+			"Tracker messages for downloads.",
+			msgLabels,
 			nil,
 		)
 	}
@@ -306,22 +328,34 @@ func (c *DownloadsCollector) collectDownloadDetails(ch chan<- prometheus.Metric)
 		float64(len(all)),
 	)
 
+	failedDownloads := 0
+
 	// Here active should be a slice of slices, where each inner slice looks like:
 	// [hash, name, down.rate, down.total, up.rate, up.total]
 	for _, a := range all {
-		err := c.parseDownloadDetailsMetrics(a, cmds, ch)
+		hadErrorMessage, err := c.parseDownloadDetailsMetrics(a, cmds, ch)
 		if err != nil {
 			return c.DownloadRateBytes, err
 		}
+		if hadErrorMessage {
+			failedDownloads++
+		}
 	}
+
+	// Finally emit the total number of errored downloads
+	ch <- prometheus.MustNewConstMetric(
+		c.DownloadsError,
+		prometheus.GaugeValue,
+		float64(failedDownloads),
+	)
 
 	return nil, nil
 }
 
-func (c *DownloadsCollector) parseDownloadDetailsMetrics(a []any, cmds []string, ch chan<- prometheus.Metric) error {
+func (c *DownloadsCollector) parseDownloadDetailsMetrics(a []any, cmds []string, ch chan<- prometheus.Metric) (bool, error) {
 	labels, err := c.gatherDownloadDetailLabels(a)
 	if err != nil {
-		return err
+		return false, err
 	}
 
 	// collect metrics starting without hash or name (starting at index 2 and beyond), cannot put this directly in range because it creates
@@ -329,12 +363,14 @@ func (c *DownloadsCollector) parseDownloadDetailsMetrics(a []any, cmds []string,
 	abbrA := a[2:]
 	abbrCommands := cmds[2:]
 
+	errorMessage := false
+
 	for idx, v := range abbrA {
 		switch abbrCommands[idx] {
 		case "d.down.rate=":
 			down, ok := v.(int64)
 			if !ok {
-				return fmt.Errorf("failed to convert Download Rate Bytes")
+				return errorMessage, fmt.Errorf("failed to convert Download Rate Bytes")
 			}
 			ch <- prometheus.MustNewConstMetric(
 				c.DownloadRateBytes,
@@ -345,7 +381,7 @@ func (c *DownloadsCollector) parseDownloadDetailsMetrics(a []any, cmds []string,
 		case "d.down.total=":
 			downTotal, ok := v.(int64)
 			if !ok {
-				return fmt.Errorf("failed to convert Download Total Bytes")
+				return errorMessage, fmt.Errorf("failed to convert Download Total Bytes")
 			}
 			ch <- prometheus.MustNewConstMetric(
 				c.DownloadTotalBytes,
@@ -356,7 +392,7 @@ func (c *DownloadsCollector) parseDownloadDetailsMetrics(a []any, cmds []string,
 		case "d.up.rate=":
 			up, ok := v.(int64)
 			if !ok {
-				return fmt.Errorf("failed to convert Upload Rate Bytes")
+				return errorMessage, fmt.Errorf("failed to convert Upload Rate Bytes")
 			}
 			ch <- prometheus.MustNewConstMetric(
 				c.UploadRateBytes,
@@ -367,7 +403,7 @@ func (c *DownloadsCollector) parseDownloadDetailsMetrics(a []any, cmds []string,
 		case "d.up.total=":
 			upTotal, ok := v.(int64)
 			if !ok {
-				return fmt.Errorf("failed to convert Upload Total Bytes")
+				return errorMessage, fmt.Errorf("failed to convert Upload Total Bytes")
 			}
 			ch <- prometheus.MustNewConstMetric(
 				c.UploadTotalBytes,
@@ -375,9 +411,41 @@ func (c *DownloadsCollector) parseDownloadDetailsMetrics(a []any, cmds []string,
 				float64(upTotal),
 				labels...,
 			)
+		case "d.message=":
+			// If there are no messages, then just continue
+			if v == nil {
+				continue
+			}
+
+			msg, ok := v.(string)
+			if !ok {
+				return errorMessage, fmt.Errorf("failed to convert Download Message")
+			}
+
+			// Excluding message Tried all trackers taken from rutorrent code base as a general exclusion for a tracker message that doesn't
+			// really mean that there is an error.
+			if msg == "" || msg == "Tracker: [Tried all trackers.]" {
+				continue
+			}
+
+			// Unfortunately, rtorrent doesn't actually give us a good way of tracking errors, so we have to assume that if there is a
+			// tracker message then it has an error
+			errorMessage = true
+
+			// Only emit the actual message as a metric if the user has instructed us to do so
+			if c.collectOpts.DownloadMessages {
+				msgLabels := append(labels, msg)
+				ch <- prometheus.MustNewConstMetric(
+					c.DownloadMessages,
+					prometheus.GaugeValue,
+					1,
+					msgLabels...,
+				)
+			}
 		}
 	}
-	return nil
+
+	return errorMessage, nil
 }
 
 func (c *DownloadsCollector) gatherDownloadDetailLabels(torSlice []any) ([]string, error) {

--- a/pkg/rtorrentexporter/downloadscollector_test.go
+++ b/pkg/rtorrentexporter/downloadscollector_test.go
@@ -126,9 +126,9 @@ func TestDownloadsCollector_collectDownloadCounts(t *testing.T) {
 
 func TestDownloadsCollector_collectDownloadDetails(t *testing.T) {
 	ds := new(MockDownloadsSource)
-	cmds := []string{"d.hash=", "d.base_filename=", "d.down.rate=", "d.down.total=", "d.up.rate=", "d.up.total="}
+	cmds := []string{"d.hash=", "d.base_filename=", "d.down.rate=", "d.down.total=", "d.up.rate=", "d.up.total=", "d.message="}
 	ds.On("DownloadWithDetails", cmds).Return([][]any{
-		{"hash1", "name1", int64(100), int64(200), int64(300), int64(400)},
+		{"hash1", "name1", int64(100), int64(200), int64(300), int64(400), nil},
 	}, nil)
 
 	collector := NewDownloadsCollector(ds, CollectorOpts{DownloadDetails: true})
@@ -154,8 +154,9 @@ func TestDownloadsCollector_parseDownloadDetailsMetrics(t *testing.T) {
 
 	go func() {
 		defer close(ch)
-		err := collector.parseDownloadDetailsMetrics(a, cmds, ch)
+		hasMessage, err := collector.parseDownloadDetailsMetrics(a, cmds, ch)
 		assert.Nil(t, err)
+		assert.False(t, hasMessage)
 	}()
 
 	for range ch {


### PR DESCRIPTION
Adds `rtorrent_downloads_error` gauge as well as the ability to get tracker messages with `rtorrent_downloads_messages`