### PR TITLE
Add debug and fix lock contention issue

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,61 +1,135 @@
-.DEFAULT_GOAL := all
+##### Main Build and Test Variables #####
+# Version Variables that are frequently modified
+DOCKER_LINT_IMAGE?=golangci/golangci-lint:v1.63.4
+DOCKER_BUILD_IMAGE?=golang:1.23.4
+# In GitHub actions where we make the official image, the runtime base is gcr.io/distroless/static to make a slim
+# container, however, here we use the full alpine image because the containers that come from the Makefile are presumed
+# to mostly be used for debugging and testing rather than distribution.
+RUNTIME_BASE?=alpine:3.21
+
+# Other build / test variables
+NAME?=rtorrent-exporter
 BUILD_DATE?=$(shell date +%Y-%m-%dT%H:%M:%S%z)
-GIT_COMMIT=$(shell git -c safe.directory="*" describe --tags --dirty)
 BUILD_IN_DOCKER?=true
 GO_TEST_NO_CACHE?=false
 GO_TEST_FLAGS?=$(if $(GO_TEST_NO_CACHE),-count=1)
 IS_ROOT=$(filter 0,$(shell id -u))
+
+# Docker variables
 IN_DOCKER_GROUP=$(filter docker,$(shell groups))
 DOCKER=$(if $(or $(IN_DOCKER_GROUP),$(IS_ROOT),$(OSX)),docker,sudo docker)
+
+# Git Variables
+GIT_COMMIT=$(shell git -c safe.directory="*" describe --tags --dirty)
+GIT_BRANCH?=$(shell git rev-parse --abbrev-ref HEAD)
+
+# Go Variables
 GO_MOD_CACHE?=$(shell go env GOMODCACHE)
 GO_CACHE?=$(shell go env GOCACHE)
-DOCKER_LINT_IMAGE?=golangci/golangci-lint:v1.63.4
-DOCKER_BUILD_IMAGE?=golang:1.23.4-alpine3.21
+GOARCH?=$(shell go env GOARCH)
 
-.PHONY: all clean test lint genmoqs instdeps gofmt gofmt-fix
+
+##### Container variables #####
+# Go arch container tag variables
+ifeq ($(GOARCH), arm)
+ARCH_TAG_PREFIX=$(GOARCH)
+FILE_ARCH=ARM
+DOCKER_ARCH=arm32v6/
+else ifeq ($(GOARCH), arm64)
+ARCH_TAG_PREFIX=$(GOARCH)
+FILE_ARCH=ARM aarch64
+DOCKER_ARCH=arm64v8/
+else ifeq ($(GOARCH), s390x)
+ARCH_TAG_PREFIX=$(GOARCH)
+FILE_ARCH=IBM S/390
+DOCKER_ARCH=s390x/
+else ifeq ($(GOARCH), ppc64le)
+ARCH_TAG_PREFIX=$(GOARCH)
+FILE_ARCH=64-bit PowerPC
+DOCKER_ARCH=ppc64le/
+else ifeq ($(GOARCH), riscv64)
+ARCH_TAG_PREFIX=$(GOARCH)
+FILE_ARCH=UCB RISC-V, RVC, double-float ABI
+DOCKER_ARCH=riscv64/
+else
+ARCH_TAG_PREFIX=amd64
+FILE_ARCH=x86-64
+DOCKER_ARCH=
+endif
+
+# Container build variables
+DEV_SUFFIX?=-git
+QEMU_IMAGE?=multiarch/qemu-user-static
+IMG_NAMESPACE?=aauren
+REGISTRY?=$(if $(IMG_FQDN),$(IMG_FQDN)/$(IMG_NAMESPACE)/$(NAME),$(IMG_NAMESPACE)/$(NAME))
+REGISTRY_DEV?=$(REGISTRY)$(DEV_SUFFIX)
+IMG_TAG?=$(if $(IMG_TAG_PREFIX),$(IMG_TAG_PREFIX)-)$(if $(ARCH_TAG_PREFIX),$(ARCH_TAG_PREFIX)-)$(GIT_BRANCH)
+BUILDTIME_BASE?=$(DOCKER_BUILD_IMAGE)
+
+.DEFAULT_GOAL := all
+.PHONY: all clean test lint genmoqs instdeps gofmt gofmt-fix container container-test-bundle
 
 clean:
+	@echo Starting rtorrent-exporter clean
 	rm -f rtorrent-exporter
+	@echo Finished rtorrent-exporter clean
 
 gofmt:
+	@echo Starting rtorrent-exporter gofmt check
 	@gofmt -l -s $(shell find . -not \( \( -wholename '*/vendor/*' \) -prune \) -name '*.go')
+	@echo Finished rtorrent-exporter gofmt check
 
 gofmt-fix:
+	@echo Starting rtorrent-exporter gofmt fixing
 	goimports -w $(shell find . -not \( \( -wholename '*/vendor/*' \) -prune \) -name '*.go')
 	gofmt -s -w $(shell find . -not \( \( -wholename '*/vendor/*' \) -prune \) -name '*.go')
+	@echo Finished rtorrent-exporter gofmt fixing
 
 instdeps:
+	@echo Starting rtorrent-exporter install go deps
 	go get ./...
+	@echo Finished rtorrent-exporter install go deps
 
 updatedeps:
+	@echo Starting rtorrent-exporter update go deps
 	go get -u ./...
+	@echo Finished rtorrent-exporter update go deps
 
 lint: gofmt
 ifeq "$(BUILD_IN_DOCKER)" "true"
+	@echo Starting rtorrent-exporter linting in Docker
 	$(DOCKER) run -v $(PWD):/go/src/github.com/aauren/rtorrent-exporter \
 		-v $(GO_CACHE):/root/.cache/go-build \
 		-v $(GO_MOD_CACHE):/go/pkg/mod \
 		-w /go/src/github.com/aauren/rtorrent-exporter $(DOCKER_LINT_IMAGE) \
 		bash -c \
 		'golangci-lint run ./...'
+	@echo Finished rtorrent-exporter linting in Docker
 else
+	@echo Starting rtorrent-exporter linting
 	golangci-lint run ./...
+	@echo Finished rtorrent-exporter linting
 endif
 
 test: gofmt ## Runs code quality pipelines (gofmt, tests, coverage, etc)
 ifeq "$(BUILD_IN_DOCKER)" "true"
+	@echo Starting rtorrent-exporter unit tests in Docker
 	$(DOCKER) run -v $(PWD):/go/src/github.com/aauren/rtorrent-exporter \
 		-v $(GO_CACHE):/root/.cache/go-build \
 		-v $(GO_MOD_CACHE):/go/pkg/mod \
 		-w /go/src/github.com/aauren/rtorrent-exporter $(DOCKER_BUILD_IMAGE) \
 		sh -c \
 		'CGO_ENABLED=0 go test -v $(GO_TEST_FLAGS) -timeout 30s github.com/aauren/rtorrent-exporter/pkg/...'
+	@echo Finished rtorrent-exporter unit tests in Docker
 else
+	@echo Starting rtorrent-exporter unit tests
 	CGO_ENABLED=0 go test -v $(GO_TEST_FLAGS) -timeout 30s github.com/aauren/rtorrent-exporter/pkg/...
+	@echo Finished rtorrent-exporter unit tests
 endif
 
 rtorrent-exporter:
 ifeq "$(BUILD_IN_DOCKER)" "true"
+	@echo Starting rtorrent-exporter build for $(GOARCH) on $(shell go env GOHOSTARCH) in Docker
 	$(DOCKER) run -v $(PWD):/go/src/github.com/aauren/rtorrent-exporter \
 		-v $(GO_CACHE):/root/.cache/go-build \
 		-v $(GO_MOD_CACHE):/go/pkg/mod \
@@ -64,10 +138,32 @@ ifeq "$(BUILD_IN_DOCKER)" "true"
 		'CGO_ENABLED=0 go build -v \
 		-ldflags "-X github.com/aauren/rtorrent-exporter/cmd.Version=$(GIT_COMMIT) -X github.com/aauren/rtorrent-exporter/cmd.BuildDate=$(BUILD_DATE)" \
 		-o rtorrent-exporter main.go'
+	@echo Finished rtorrent-exporter build for $(GOARCH) on $(shell go env GOHOSTARCH) in Docker
 else
+	@echo Starting rtorrent-exporter build for $(GOARCH) on $(shell go env GOHOSTARCH)
 	CGO_ENABLED=0 go build -v \
 		-ldflags "-X github.com/aauren/rtorrent-exporter/cmd.Version=$(GIT_COMMIT) -X github.com/aauren/rtorrent-exporter/cmd.BuildDate=$(BUILD_DATE)" \
 		-o rtorrent-exporter main.go
+	@echo Finished rtorrent-exporter build for $(GOARCH) on $(shell go env GOHOSTARCH)
 endif
+
+container: clean rtorrent-exporter
+	@echo Starting rtorrent-exporter container image build for $(GOARCH) on $(shell go env GOHOSTARCH)
+	@if [ "$(GOARCH)" != "$(shell go env GOHOSTARCH)" ]; then \
+		echo "Using qemu to build non-native container"; \
+		$(DOCKER) run --rm --privileged $(QEMU_IMAGE) --reset -p yes; \
+	fi
+	$(DOCKER) build -t "$(REGISTRY_DEV):$(subst /,,$(IMG_TAG))" -f Dockerfile --build-arg ARCH="$(DOCKER_ARCH)" \
+		--build-arg BUILDTIME_BASE="$(BUILDTIME_BASE)" --build-arg RUNTIME_BASE="$(RUNTIME_BASE)" .
+	@echo Finished rtorrent-exporter container image build: $(REGISTRY_DEV):$(subst /,,$(IMG_TAG))
+	@if [ "$(GIT_BRANCH)" = "master" ]; then \
+		$(DOCKER) tag "$(REGISTRY_DEV):$(IMG_TAG)" "$(REGISTRY_DEV)"; \
+		echo Added additional tag: $(REGISTRY_DEV); \
+	fi
+
+container-test-bundle: container
+	@echo Starting rtorrent-exporter container image test bundle for $(GOARCH) on $(shell go env GOHOSTARCH)
+	$(DOCKER) save -o "$(NAME):$(subst /,,$(IMG_TAG)).tar" "$(REGISTRY_DEV):$(subst /,,$(IMG_TAG))"
+	@echo Finished rtorrent-exporter container image test bundle.
 
 all: lint test rtorrent-exporter

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -3,6 +3,10 @@ package cmd
 import (
 	"context"
 	"flag"
+	nethttp "net/http"
+
+	//nolint:gosec // pprof still needs to be imported despite what gosec thinks
+	_ "net/http/pprof"
 	"os"
 	"os/signal"
 	"regexp"
@@ -64,6 +68,9 @@ func init() {
 	rootCmd.Flags().DurationVar(&rootConfig.Telemetry.Timeout, "telemetry.timeout", 10*time.Second,
 		"[optional] duration of how long to wait to receive http headers on telemetry addr")
 	_ = viper.BindPFlag("telemetry.timeout", rootCmd.Flags().Lookup("telemetry.timeout"))
+	rootCmd.Flags().BoolVar(&rootConfig.Telemetry.EnablePProf, "telemetry.enable-pprof", false,
+		"[optional] enable pprof endpoints on rtorrent-exporter (for advanced debugging)")
+	_ = viper.BindPFlag("telemetry.enable-pprof", rootCmd.Flags().Lookup("telemetry.enable-pprof"))
 
 	// Setup rTorrent client connection flags
 	rootCmd.Flags().StringVar(&rootConfig.Rtorrent.Addr, "rtorrent.addr", "", "address of rTorrent XML-RPC server")
@@ -138,10 +145,18 @@ func initConfig() {
 }
 
 func RunRoot(cmd *cobra.Command, args []string) {
-
 	// Validate arguments passed
 	klog.V(1).Info("validating flags")
 	validateFlags()
+
+	// Enable pprof for advanced debugging early if requested
+	if rootConfig.Telemetry.EnablePProf {
+		go func() {
+			klog.Infof("starting pprof server on %q", "localhost:6060")
+			//nolint:gosec // pprof is a debugging tool we don't care about timeouts
+			klog.Info(nethttp.ListenAndServe("0.0.0.0:6060", nil))
+		}()
+	}
 
 	if writeConfig {
 		klog.Info("writing configuration to file")

--- a/pkg/rtorrentexporter/config/config.go
+++ b/pkg/rtorrentexporter/config/config.go
@@ -57,7 +57,8 @@ type CacheConfig struct {
 
 // TelemetryConfig is the configuration for the telemetry server.
 type TelemetryConfig struct {
-	Addr    string        `mapstructure:"addr"`
-	Path    string        `mapstructure:"path"`
-	Timeout time.Duration `mapstructure:"timeout"`
+	Addr        string        `mapstructure:"addr"`
+	Path        string        `mapstructure:"path"`
+	Timeout     time.Duration `mapstructure:"timeout"`
+	EnablePProf bool          `mapstructure:"enable-pprof"`
 }

--- a/pkg/rtorrentexporter/tracker/cacher.go
+++ b/pkg/rtorrentexporter/tracker/cacher.go
@@ -26,7 +26,7 @@ const (
 	maxCacheCheckChanBuffer = 100000
 	// The parallelRequestsBufferMultiplier is multiplied by the max parallel requests given by the user at runtime to determine the size of
 	// the request channel buffer. This is to ensure that we can handle a burst of requests without blocking the fetchers.
-	parallelRequestsBufferMultiplier = 3
+	parallelRequestsBufferMultiplier = 10
 )
 
 // Cacher is a construct that caches the results of a Tracker Fetcher for a specified min / max time and according to a set number of

--- a/pkg/rtorrentexporter/tracker/cacher.go
+++ b/pkg/rtorrentexporter/tracker/cacher.go
@@ -344,7 +344,12 @@ func (c *Cacher) checkCacheForStaleItems(ctx context.Context, wg *sync.WaitGroup
 		if tr.IsStale(c.cOpts.MaxAge, c.cOpts.MinAge) {
 			klog.V(1).Infof("tracker was found in cache but is stale sending request to fetcher: %v", ti)
 			fr := &FetchRequest{TrackerIndex: &ti}
-			c.reqChan <- fr
+			select {
+			case c.reqChan <- fr:
+				klog.V(1).Info("successfully sent request to fetcher")
+			default:
+				klog.Warningf("fetcher request channel is full, unable to send request: %v", ti)
+			}
 		}
 	}
 }

--- a/pkg/rtorrentexporter/tracker/cacher.go
+++ b/pkg/rtorrentexporter/tracker/cacher.go
@@ -385,7 +385,7 @@ func (c *Cacher) Run(ctx context.Context, wg *sync.WaitGroup) {
 	childWG := &sync.WaitGroup{}
 	c.cacheCheckChan = make(chan *FetchRequest, maxCacheCheckChanBuffer)
 	c.reqChan = make(chan *FetchRequest, c.cOpts.MaxParallelRequests*parallelRequestsBufferMultiplier)
-	c.resChan = make(chan *TrackerResponse)
+	c.resChan = make(chan *TrackerResponse, c.cOpts.MaxParallelRequests*parallelRequestsBufferMultiplier)
 	c.blockingReqCtx, c.blockingReqCancel = context.WithCancel(context.Background())
 
 	// Setup fetchers up to the maximum number of allowed parallel requests


### PR DESCRIPTION
Fixes #10 by creating an outlet when there is lock contention during cache checking.

Also does the following:

* Adds the ability to enable pprof debugging using the `--telemetry.enable-pprof` option
* Adds Makefile target to build a test container for easier debugging
* Increases resiliency to locking conditions by adding a buffered channel to responses
* Increases buffered channel multiplier for both requests and responses sent to rtorrent fetcher threads