### PR TITLE
Update Error Handling

### DIFF
--- a/pkg/rtorrentexporter/downloadscollector.go
+++ b/pkg/rtorrentexporter/downloadscollector.go
@@ -348,7 +348,7 @@ func (c *DownloadsCollector) collectDownloadDetails(ch chan<- prometheus.Metric)
 	for _, a := range all {
 		hadErrorMessage, err := c.parseDownloadDetailsMetrics(a, cmds, ch)
 		if err != nil {
-			return c.DownloadRateBytes, err
+			klog.Errorf("failed to parse download details metrics: %v", err)
 		}
 		if hadErrorMessage {
 			failedDownloads++

--- a/pkg/rtorrentexporter/downloadscollector.go
+++ b/pkg/rtorrentexporter/downloadscollector.go
@@ -470,7 +470,7 @@ func (c *DownloadsCollector) gatherDownloadDetailLabels(torSlice []any) ([]strin
 	}
 	name, ok := torSlice[1].(string)
 	if !ok {
-		return nil, fmt.Errorf("failed to convert torrent name to string")
+		return nil, fmt.Errorf("failed to convert torrent name to string, for hash: %s", hash)
 	}
 	labels := []string{
 		hash,


### PR DESCRIPTION
* Adds the hash to any name conversion failures
* Logs errors, but doesn't stop the entire collector because of a single torrent failure